### PR TITLE
Modernize C++ and fix ISR race conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 
 # Python virtual environment
 venv/
+.venv/

--- a/components/fineoffset/fineoffset.cpp
+++ b/components/fineoffset/fineoffset.cpp
@@ -293,19 +293,19 @@ void FineOffsetStore::record_state() {
 std::optional<ConsumedStateGuard<FineOffsetState>> FineOffsetStore::get_last_state(
     FineOffsetTextSensorType sensor_type) {
     switch (sensor_type) {
-        case FINEOFFSET_TYPE_LAST:
+        case FineOffsetTextSensorType::Last:
             if (this->states_count_ > 0) {
                 // Get the most recent state from circular buffer (no consumed tracking needed)
                 uint8_t last_index = (this->states_head_ + config::MAX_RECENT_STATES - 1) % config::MAX_RECENT_STATES;
                 return ConsumedStateGuard<FineOffsetState>(this->states_[last_index], nullptr);
             }
             break;
-        case FINEOFFSET_TYPE_LAST_BAD:
+        case FineOffsetTextSensorType::LastBad:
             if (this->has_last_bad_) {
                 return ConsumedStateGuard<FineOffsetState>(this->last_bad_, &this->last_bad_consumed_);
             }
             break;
-        case FINEOFFSET_TYPE_UNKNOWN:
+        case FineOffsetTextSensorType::Unknown:
             if (this->has_last_unknown_) {
                 return ConsumedStateGuard<FineOffsetState>(this->last_unknown_, &this->last_unknown_consumed_);
             }

--- a/components/fineoffset/fineoffset.cpp
+++ b/components/fineoffset/fineoffset.cpp
@@ -68,8 +68,8 @@ std::string FineOffsetState::debug_str() const {
 
     // Append raw packet bytes in hex
     char raw_buf[30];
-    snprintf(raw_buf, sizeof(raw_buf), " [RAW: %02X %02X %02X %02X %02X]",
-             raw_packet[0], raw_packet[1], raw_packet[2], raw_packet[3], raw_packet[4]);
+    snprintf(raw_buf, sizeof(raw_buf), " [RAW: %02X %02X %02X %02X %02X]", raw_packet[0], raw_packet[1], raw_packet[2],
+             raw_packet[3], raw_packet[4]);
     data += raw_buf;
 
     // Add CRC info
@@ -213,11 +213,11 @@ void IRAM_ATTR FineOffsetStore::intr_cb(FineOffsetStore* self) {
                 // start the sampling process from scratch
                 wh2_packet_state = 1;
                 wh2_accept_flag = true;
-                self->accept_flag_.store(true);
+                self->accept_flag_.store(true, std::memory_order_relaxed);
             }
         } else {
             wh2_accept_flag = false;
-            self->accept_flag_.store(false);
+            self->accept_flag_.store(false, std::memory_order_relaxed);
         }
 
         if (wh2_accept_flag) {
@@ -243,7 +243,7 @@ void IRAM_ATTR FineOffsetStore::intr_cb(FineOffsetStore* self) {
                 self->have_sensor_data_.store(state.sensor_id, std::memory_order_release);
             } else if (!wh2_valid && self->have_sensor_data_.load(std::memory_order_relaxed) == 0) {
                 uint8_t buffer_idx = self->isr_buffer_index_.load(std::memory_order_relaxed);
-                self->state_buffers_[buffer_idx] = state;  // Safe: main thread uses other buffer
+                self->state_buffers_[buffer_idx] = state;        // Safe: main thread uses other buffer
                 self->state_buffers_[buffer_idx].valid = false;  // Ensure marked invalid for debugging
                 self->has_pending_state_.store(
                     true, std::memory_order_release);  // Release: ensure state write completes first

--- a/components/fineoffset/fineoffset.h
+++ b/components/fineoffset/fineoffset.h
@@ -80,6 +80,7 @@ struct FineOffsetState {
     FineOffsetState(byte packet[5]);
 
     std::string str() const;
+    std::string debug_str() const;  // Detailed debug string with raw packet
     bool is_plausible() const {
         return humidity <= 100 && temperature >= -400 && temperature <= 800;  // -40.0°C to 80.0°C (in 0.1°C units)
     }
@@ -89,6 +90,7 @@ struct FineOffsetState {
     uint32_t humidity{0};
     bool valid{false};
     bool plausible{false};
+    byte raw_packet[5]{0, 0, 0, 0, 0};  // Store raw packet bytes for debugging
 
     static uint8_t crc8ish(const byte data[], uint8_t len) {
         uint8_t crc = 0;

--- a/components/fineoffset/fineoffset.h
+++ b/components/fineoffset/fineoffset.h
@@ -66,7 +66,7 @@ template<typename T> class ConsumedStateGuard {
 class FineOffsetComponent;
 
 #ifdef USE_TEXT_SENSOR
-enum FineOffsetTextSensorType : uint8_t;
+enum class FineOffsetTextSensorType : uint8_t;
 #endif
 
 using byte = uint8_t;

--- a/components/fineoffset/text_sensor/__init__.py
+++ b/components/fineoffset/text_sensor/__init__.py
@@ -12,13 +12,13 @@ DEPENDENCIES = ["fineoffset"]
 FineOffsetTextSensor = fineoffset_ns.class_(
     "FineOffsetTextSensor", text_sensor.TextSensor, cg.PollingComponent
 )
-FineOffsetTextSensorTypes = fineoffset_ns.enum("FineOffsetTextSensorTypes")
+FineOffsetTextSensorType = fineoffset_ns.enum("FineOffsetTextSensorType")
 
 CONF_TYPE = "type"
 TYPES = {
-    "last": FineOffsetTextSensorTypes.FINEOFFSET_TYPE_LAST,
-    "last_bad": FineOffsetTextSensorTypes.FINEOFFSET_TYPE_LAST_BAD,
-    "unknown": FineOffsetTextSensorTypes.FINEOFFSET_TYPE_UNKNOWN,
+    "last": FineOffsetTextSensorType.Last,
+    "last_bad": FineOffsetTextSensorType.LastBad,
+    "unknown": FineOffsetTextSensorType.Unknown,
 }
 
 CONFIG_SCHEMA = cv.All(

--- a/components/fineoffset/text_sensor/__init__.py
+++ b/components/fineoffset/text_sensor/__init__.py
@@ -12,7 +12,7 @@ DEPENDENCIES = ["fineoffset"]
 FineOffsetTextSensor = fineoffset_ns.class_(
     "FineOffsetTextSensor", text_sensor.TextSensor, cg.PollingComponent
 )
-FineOffsetTextSensorType = fineoffset_ns.enum("FineOffsetTextSensorType")
+FineOffsetTextSensorType = fineoffset_ns.enum("FineOffsetTextSensorType", is_class=True)
 
 CONF_TYPE = "type"
 TYPES = {

--- a/components/fineoffset/text_sensor/fineoffset_text_sensor.h
+++ b/components/fineoffset/text_sensor/fineoffset_text_sensor.h
@@ -7,10 +7,10 @@
 namespace esphome {
 namespace fineoffset {
 
-enum FineOffsetTextSensorType : uint8_t {
-    FINEOFFSET_TYPE_LAST,
-    FINEOFFSET_TYPE_LAST_BAD,
-    FINEOFFSET_TYPE_UNKNOWN,
+enum class FineOffsetTextSensorType : uint8_t {
+    Last,
+    LastBad,
+    Unknown,
 };
 
 class FineOffsetTextSensor : public text_sensor::TextSensor, public PollingComponent {


### PR DESCRIPTION
## Summary
This PR addresses critical ISR (Interrupt Service Routine) safety issues and modernizes the C++ codebase with type-safe alternatives to legacy C patterns.

## Changes

### Round 1: Fix Critical ISR Safety Issues (CRITICAL)
- **Implement double-buffering** for lock-free ISR-to-main-thread communication
  - Eliminates race conditions from non-atomic multi-word structure copies
  - ISR writes to one buffer while main thread reads from the other
  - Atomic `isr_buffer_index_` controls buffer selection
- **Make all shared state atomic**
  - `has_pending_state_`: `bool` → `std::atomic<bool>`
  - `cycles_`, `bad_count_`: `volatile uint32_t` → `std::atomic<uint32_t>`
  - Use `fetch_add()` for thread-safe counter increments
- **Add explicit memory ordering semantics**
  - Release semantics on ISR writes (ensure visibility to main thread)
  - Acquire semantics on main thread reads (observe all ISR writes)
  - Relaxed ordering for diagnostic counters (performance optimization)
- **Remove redundant `volatile`** from atomic variables
- **Document static variable limitation** in ISR (single instance only)

**Impact**: Eliminates data corruption from torn reads/writes between ISR and main thread

### Round 2: Replace C Macros with Constexpr
- **Modernize signal timing constants**
  - `IS_HI_PULSE()` → `signal_timing::is_hi_pulse()`
  - `IS_LOW_PULSE()` → `signal_timing::is_low_pulse()`
  - `IDLE_HAS_TIMED_OUT()` → `signal_timing::idle_has_timed_out()`
  - `IDLE_PERIOD_DONE()` → `signal_timing::idle_period_done()`
- **Modernize decoder flags**
  - `GOT_PULSE`, `LOGIC_HI` → `decoder_flags::` namespace
- **Benefits**
  - Type safety (functions have typed parameters vs. macros)
  - Scoped names (no global namespace pollution)
  - Better debugging (appear in stack traces)
  - Same performance (constexpr evaluated at compile time)

**Impact**: Improved type safety and debuggability with zero runtime cost

### Round 3: Use Enum Class for Sensor Types
- **Convert** `FineOffsetTextSensorType` to scoped enum class
  - `FINEOFFSET_TYPE_LAST` → `FineOffsetTextSensorType::Last`
  - `FINEOFFSET_TYPE_LAST_BAD` → `FineOffsetTextSensorType::LastBad`
  - `FINEOFFSET_TYPE_UNKNOWN` → `FineOffsetTextSensorType::Unknown`
- **Fix Python bindings** to match new enum class syntax
- **Benefits**
  - No implicit conversions to int
  - Scoped names (cleaner, no prefix pollution)
  - Stronger compile-time type safety

**Impact**: Prevents common enum-related bugs through stronger typing

## Testing
- ✅ Clang-format validation (C++ formatting)
- ✅ Ruff/Black validation (Python formatting)
- ⚠️  **Compilation testing needed** (ESPHome compile blocked by environment limitations)

## Breaking Changes
None - all changes are internal refactoring with backward-compatible APIs.

## Related Issues
Addresses signal processing reliability concerns from recent merged changes.

## Checklist
- [x] Code follows repository style guidelines (clang-format applied)
- [x] Changes are atomic and well-documented
- [x] Commit messages follow imperative style
- [ ] Tested with actual hardware (requires maintainer verification)