### PR TITLE
Refactor string formatting to use stack buffers instead of heap

### DIFF
--- a/components/fineoffset/fineoffset.cpp
+++ b/components/fineoffset/fineoffset.cpp
@@ -39,13 +39,13 @@ FineOffsetState::FineOffsetState(byte packet[5]) {
     }
 }
 
-void FineOffsetState::str(char *buf, size_t len) const {
-    const char *status = valid ? (plausible ? "OK" : "IMPLAUSIBLE") : "BAD";
+void FineOffsetState::str(char* buf, size_t len) const {
+    const char* status = valid ? (plausible ? "OK" : "IMPLAUSIBLE") : "BAD";
     snprintf(buf, len, "| Sensor ID:  %u | humidity: %u%% | temperature: %.1f\xC2\xB0C | %s", sensor_id, humidity,
              temperature * 0.1f, status);
 }
 
-void FineOffsetState::debug_str(char *buf, size_t len) const {
+void FineOffsetState::debug_str(char* buf, size_t len) const {
     this->str(buf, len);
     size_t used = strlen(buf);
     uint8_t calculated_crc = crc8ish(raw_packet, 4);

--- a/components/fineoffset/fineoffset.cpp
+++ b/components/fineoffset/fineoffset.cpp
@@ -39,48 +39,23 @@ FineOffsetState::FineOffsetState(byte packet[5]) {
     }
 }
 
-std::string FineOffsetState::str() const {
-    std::string data;
-
-    char temperture_buf[7] = {0};  // 7 bytes is enough for -100.0 with a '\0'
-    snprintf(temperture_buf, sizeof(temperture_buf), "%.1f", (temperature * 0.1f));
-    data.clear();
-    data += "| Sensor ID:  ";
-    data += to_string(sensor_id);
-    data += " | humidity: ";
-    data += to_string(humidity);
-    data += "% | temperature: ";
-    data += temperture_buf;
-    data += "°C | ";
-    if (valid && plausible) {
-        data += "OK";
-    } else if (valid && !plausible) {
-        data += "IMPLAUSIBLE";
-    } else {
-        data += "BAD";
-    }
-
-    return data;
+void FineOffsetState::str(char *buf, size_t len) const {
+    const char *status = valid ? (plausible ? "OK" : "IMPLAUSIBLE") : "BAD";
+    snprintf(buf, len, "| Sensor ID:  %u | humidity: %u%% | temperature: %.1f\xC2\xB0C | %s", sensor_id, humidity,
+             temperature * 0.1f, status);
 }
 
-std::string FineOffsetState::debug_str() const {
-    std::string data = this->str();
-
-    // Append raw packet bytes in hex
-    char raw_buf[30];
-    snprintf(raw_buf, sizeof(raw_buf), " [RAW: %02X %02X %02X %02X %02X]", raw_packet[0], raw_packet[1], raw_packet[2],
-             raw_packet[3], raw_packet[4]);
-    data += raw_buf;
-
-    // Add CRC info
+void FineOffsetState::debug_str(char *buf, size_t len) const {
+    this->str(buf, len);
+    size_t used = strlen(buf);
     uint8_t calculated_crc = crc8ish(raw_packet, 4);
     if (calculated_crc != raw_packet[4]) {
-        char crc_buf[40];
-        snprintf(crc_buf, sizeof(crc_buf), " CRC calc=%02X recv=%02X", calculated_crc, raw_packet[4]);
-        data += crc_buf;
+        snprintf(buf + used, len - used, " [RAW: %02X %02X %02X %02X %02X] CRC calc=%02X recv=%02X", raw_packet[0],
+                 raw_packet[1], raw_packet[2], raw_packet[3], raw_packet[4], calculated_crc, raw_packet[4]);
+    } else {
+        snprintf(buf + used, len - used, " [RAW: %02X %02X %02X %02X %02X]", raw_packet[0], raw_packet[1],
+                 raw_packet[2], raw_packet[3], raw_packet[4]);
     }
-
-    return data;
 }
 
 // WH2 signal timing and decoder constants
@@ -115,7 +90,7 @@ FineOffsetStore::FineOffsetStore(FineOffsetComponent* parent) : parent_(parent),
 void IRAM_ATTR FineOffsetStore::intr_cb(FineOffsetStore* self) {
     // NOTE: Static local variables limit this implementation to a single FineOffsetStore instance.
     // Multiple instances would share these statics and interfere with each other.
-    static unsigned long edgeTimeStamp[3] = {0};  // Timestamp of edges
+    static uint32_t edgeTimeStamp[3] = {0};  // Timestamp of edges (micros() returns uint32_t)
     static bool skip = true;
 
     // Filter out too short pulses. This method works as a low pass filter.  (borroved from new remote reciever)
@@ -134,7 +109,7 @@ void IRAM_ATTR FineOffsetStore::intr_cb(FineOffsetStore* self) {
         return;
     }
 
-    unsigned int pulse = edgeTimeStamp[1] - edgeTimeStamp[0];
+    uint32_t pulse = edgeTimeStamp[1] - edgeTimeStamp[0];
     edgeTimeStamp[0] = edgeTimeStamp[1];
 
     static byte wh2_flags = 0x00;
@@ -305,10 +280,13 @@ void FineOffsetStore::record_state() {
         }
 
         if (state.valid && state.plausible) {
-            ESP_LOGD(TAG, "%s", state.str().c_str());
+            char log_buf[FineOffsetState::STR_BUF_SIZE];
+            state.str(log_buf, sizeof(log_buf));
+            ESP_LOGD(TAG, "%s", log_buf);
         } else {
-            // Log invalid/implausible packets with detailed debug info
-            ESP_LOGD(TAG, "%s", state.debug_str().c_str());
+            char log_buf[FineOffsetState::DEBUG_STR_BUF_SIZE];
+            state.debug_str(log_buf, sizeof(log_buf));
+            ESP_LOGD(TAG, "%s", log_buf);
         }
     }
 

--- a/components/fineoffset/fineoffset.h
+++ b/components/fineoffset/fineoffset.h
@@ -3,6 +3,7 @@
 #include <esp_types.h>
 
 #include <atomic>
+#include <bitset>
 #include <optional>
 
 #include "esphome/core/component.h"
@@ -238,9 +239,9 @@ class FineOffsetComponent : public Component {
     }
 
     // Register known sensor IDs for unknown sensor detection
-    void register_known_sensor(uint8_t sensor_no) { this->known_sensor_ids_[sensor_no] = true; }
+    void register_known_sensor(uint8_t sensor_no) { this->known_sensor_ids_.set(sensor_no); }
 
-    [[nodiscard]] bool is_unknown_sensor(uint8_t sensor_no) const { return !this->known_sensor_ids_[sensor_no]; }
+    [[nodiscard]] bool is_unknown_sensor(uint8_t sensor_no) const { return !this->known_sensor_ids_.test(sensor_no); }
 
 #ifdef USE_TEXT_SENSOR
     [[nodiscard]] std::optional<ConsumedStateGuard<FineOffsetState>> get_last_state(FineOffsetTextSensorType type) {
@@ -252,8 +253,8 @@ class FineOffsetComponent : public Component {
     friend class FineOffsetStore;
     FineOffsetStore store_;
     InternalGPIOPin* pin_;
-    // Fixed-size lookup table (replaces std::set<uint8_t>) - 8-bit IDs = max 256 entries
-    bool known_sensor_ids_[config::MAX_SENSOR_IDS]{};
+    // Bitset replaces std::set<uint8_t>: 32 bytes BSS, O(1), no heap
+    std::bitset<config::MAX_SENSOR_IDS> known_sensor_ids_{};
 
     void schedule_diagnostic_log();
 };

--- a/components/fineoffset/fineoffset.h
+++ b/components/fineoffset/fineoffset.h
@@ -80,8 +80,8 @@ struct FineOffsetState {
     static constexpr size_t STR_BUF_SIZE = 96;
     static constexpr size_t DEBUG_STR_BUF_SIZE = 160;
 
-    void str(char *buf, size_t len) const;
-    void debug_str(char *buf, size_t len) const;  // Detailed debug string with raw packet
+    void str(char* buf, size_t len) const;
+    void debug_str(char* buf, size_t len) const;  // Detailed debug string with raw packet
     [[nodiscard]] constexpr bool is_plausible() const {
         return humidity <= 100 && temperature >= -400 && temperature <= 800;  // -40.0°C to 80.0°C (in 0.1°C units)
     }

--- a/components/fineoffset/fineoffset.h
+++ b/components/fineoffset/fineoffset.h
@@ -4,7 +4,6 @@
 
 #include <atomic>
 #include <optional>
-#include <set>
 
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
@@ -76,8 +75,12 @@ struct FineOffsetState {
     FineOffsetState() = default;
     FineOffsetState(byte packet[5]);
 
-    std::string str() const;
-    std::string debug_str() const;  // Detailed debug string with raw packet
+    // Minimum buffer sizes for str() and debug_str()
+    static constexpr size_t STR_BUF_SIZE = 96;
+    static constexpr size_t DEBUG_STR_BUF_SIZE = 160;
+
+    void str(char *buf, size_t len) const;
+    void debug_str(char *buf, size_t len) const;  // Detailed debug string with raw packet
     [[nodiscard]] constexpr bool is_plausible() const {
         return humidity <= 100 && temperature >= -400 && temperature <= 800;  // -40.0°C to 80.0°C (in 0.1°C units)
     }
@@ -235,11 +238,9 @@ class FineOffsetComponent : public Component {
     }
 
     // Register known sensor IDs for unknown sensor detection
-    void register_known_sensor(uint8_t sensor_no) { this->known_sensor_ids_.insert(sensor_no); }
+    void register_known_sensor(uint8_t sensor_no) { this->known_sensor_ids_[sensor_no] = true; }
 
-    [[nodiscard]] bool is_unknown_sensor(uint8_t sensor_no) const {
-        return this->known_sensor_ids_.find(sensor_no) == this->known_sensor_ids_.end();
-    }
+    [[nodiscard]] bool is_unknown_sensor(uint8_t sensor_no) const { return !this->known_sensor_ids_[sensor_no]; }
 
 #ifdef USE_TEXT_SENSOR
     [[nodiscard]] std::optional<ConsumedStateGuard<FineOffsetState>> get_last_state(FineOffsetTextSensorType type) {
@@ -251,7 +252,8 @@ class FineOffsetComponent : public Component {
     friend class FineOffsetStore;
     FineOffsetStore store_;
     InternalGPIOPin* pin_;
-    std::set<uint8_t> known_sensor_ids_;
+    // Fixed-size lookup table (replaces std::set<uint8_t>) - 8-bit IDs = max 256 entries
+    bool known_sensor_ids_[config::MAX_SENSOR_IDS]{};
 
     void schedule_diagnostic_log();
 };

--- a/components/fineoffset/sensor/fineoffset_sensor.cpp
+++ b/components/fineoffset/sensor/fineoffset_sensor.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace fineoffset {
 
-static const char* TAG = "fineoffset.sensor";
+static const char* const TAG = "fineoffset.sensor";
 
 void FineOffsetSensor::setup() { ESP_LOGCONFIG(TAG, "Setting up FineOffset Sensor..."); }
 

--- a/components/fineoffset/text_sensor/fineoffset_text_sensor.cpp
+++ b/components/fineoffset/text_sensor/fineoffset_text_sensor.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace fineoffset {
 
-static const char* TAG = "fineoffset.text_sensor";
+static const char* const TAG = "fineoffset.text_sensor";
 
 void FineOffsetTextSensor::setup() { ESP_LOGCONFIG(TAG, "Setting up FineOffset Text Sensor..."); }
 
@@ -22,10 +22,11 @@ void FineOffsetTextSensor::update() {
 
     auto state_guard = this->parent_->get_last_state(this->sensor_type_);
     if (state_guard.has_value()) {
-        const auto& state = state_guard->get();
-        std::string state_str = state.str();
-        if (state_str != this->state) {
-            this->publish_state(state_str);
+        const auto &state = state_guard->get();
+        char state_buf[FineOffsetState::STR_BUF_SIZE];
+        state.str(state_buf, sizeof(state_buf));
+        if (this->state != state_buf) {
+            this->publish_state(state_buf);
         }
     }
 }

--- a/components/fineoffset/text_sensor/fineoffset_text_sensor.cpp
+++ b/components/fineoffset/text_sensor/fineoffset_text_sensor.cpp
@@ -22,7 +22,7 @@ void FineOffsetTextSensor::update() {
 
     auto state_guard = this->parent_->get_last_state(this->sensor_type_);
     if (state_guard.has_value()) {
-        const auto &state = state_guard->get();
+        const auto& state = state_guard->get();
         char state_buf[FineOffsetState::STR_BUF_SIZE];
         state.str(state_buf, sizeof(state_buf));
         if (this->state != state_buf) {


### PR DESCRIPTION
## Summary
Refactored the `FineOffsetState` string formatting methods to use stack-allocated buffers instead of returning heap-allocated `std::string` objects. This improves memory efficiency and reduces heap fragmentation, particularly important for embedded systems with limited resources.

## Key Changes

- **String formatting refactor**: Changed `str()` and `debug_str()` from returning `std::string` to accepting `char*` buffer and `size_t` length parameters
  - Added static constexpr buffer size constants (`STR_BUF_SIZE = 96`, `DEBUG_STR_BUF_SIZE = 160`)
  - Consolidated temperature formatting and status logic into single `snprintf()` calls
  - `debug_str()` now calls `str()` and appends debug info to avoid duplication

- **Type safety improvements**:
  - Changed `edgeTimeStamp` array from `unsigned long` to `uint32_t` with clarifying comment about `micros()` return type
  - Changed `pulse` variable from `unsigned int` to `uint32_t` for consistency
  - Made TAG string pointers const in text_sensor and sensor implementations

- **Data structure optimization**:
  - Replaced `std::set<uint8_t>` with `std::bitset<config::MAX_SENSOR_IDS>` for known sensor ID tracking
  - Reduces memory footprint (32 bytes BSS vs heap allocation) and provides O(1) lookup
  - Updated `register_known_sensor()` and `is_unknown_sensor()` to use bitset operations

- **Call site updates**:
  - Updated logging calls in `record_state()` to allocate stack buffers and pass to formatting methods
  - Updated text sensor implementation to use stack buffer instead of storing string result
  - Removed `.c_str()` calls since we're now working directly with char arrays

## Implementation Details

The refactored string methods now follow a buffer-passing pattern common in embedded systems, avoiding dynamic memory allocation during logging. The UTF-8 degree symbol (°C) is preserved using the byte sequence `\xC2\xB0`. The `debug_str()` method efficiently appends to the buffer by calculating the used length and continuing from that offset.

https://claude.ai/code/session_014uB34maq3sxmfkvGPduAoY